### PR TITLE
feat:ライブコメント数、チップ合計のN+1修正

### DIFF
--- a/webapp/go/stats_handler.go
+++ b/webapp/go/stats_handler.go
@@ -175,7 +175,7 @@ GROUP BY u.id`
 SELECT 
     livestream_id, 
     COUNT(livecomments.id) AS livecomments_count, 
-    IFNULL(SUM(livecomment.tip), 0) AS total_tip
+    IFNULL(SUM(livecomments.tip), 0) AS total_tip
 FROM 
     livestreams 
 LEFT JOIN 


### PR DESCRIPTION
問題にならなくなったので対応しない
message=failed to get livestream livestreamStatsList: sql: Scan error on column index 0, name \"livestream_id\": converting NULL to int64 is unsupported","latency