### PR TITLE
iconを304で返せるようにした

### DIFF
--- a/webapp/go/user_handler.go
+++ b/webapp/go/user_handler.go
@@ -201,10 +201,9 @@ func postIconHandler(c echo.Context) error {
 	iconHash := sha256.Sum256(req.Image)
 	iconFileName := fmt.Sprintf("%x", iconHash)
 	iconFilePath := "/opt/icons/" + iconFileName
-	addIconHash(userID, iconFileName)
-
 	// 画像をファイルに保存
 	err = os.WriteFile(iconFilePath, req.Image, 0644)
+	addIconHash(userID, iconFilePath)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save user icon: "+err.Error())
 	}
@@ -503,7 +502,7 @@ func fillUserResponse(ctx context.Context, tx *sqlx.Tx, userModel UserModel) (Us
 		return User{}, err
 	}
 	iconHash := sha256.Sum256(image)
-
+	addIconHashByUserName(userModel.Name, fmt.Sprintf("%x", iconHash))
 	user := User{
 		ID:          userModel.ID,
 		Name:        userModel.Name,


### PR DESCRIPTION
```
ssh isucon-bench "cd ~/isucon13/bench && ./bin/bench_linux_amd64 run --enable-ssl --target https://pipe.u.isucon.dev --nameserver 35.78.167.13 > bench.log 2>&1 && tail -n 10 bench.log"
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [シナリオ viewer-spam] 971 回成功, 7 回失敗
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [シナリオ viewer] 211 回成功
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [失敗シナリオ aggressive-streamer-moderate-fail] 6 回失敗
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [失敗シナリオ streamer-moderate-fail] 4 回失敗
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [失敗シナリオ viewer-report-fail] 1 回失敗
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:323      [失敗シナリオ viewer-spam-fail] 7 回失敗
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:329      DNSAttacker並列数: 15
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:330      名前解決成功数: 182302
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:331      名前解決失敗数: 0
2023-12-10T08:49:54.771Z        info    staff-logger    bench/bench.go:335      スコア: 42715
```