### PR TITLE
GET /api/livestream/search でのN+1軽減

### DIFF
--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -506,7 +506,7 @@ func fillLivestreamResponses(ctx context.Context, tx *sqlx.Tx, models []*Livestr
 	if err := tx.SelectContext(ctx, &ownerModels, query, params...); err != nil {
 		return nil, err
 	}
-	var owners map[int64]User
+	owners := map[int64]User{}
 	for _, o := range ownerModels {
 		owner, err := fillUserResponse(ctx, tx, o)
 		if err != nil {
@@ -526,11 +526,11 @@ func fillLivestreamResponses(ctx context.Context, tx *sqlx.Tx, models []*Livestr
 	if err := tx.SelectContext(ctx, &lTagIdModels, query, params...); err != nil {
 		return nil, err
 	}
-	var lTagIds map[int64][]int64
+	lTagIds := map[int64][]int64{}
 	for _, t := range lTagIdModels {
 		lTagIds[t.LivestreamID] = append(lTagIds[t.LivestreamID], t.TagID)
 	}
-	var lTags map[int64][]Tag
+	lTags := map[int64][]Tag{}
 	for lId, tIds := range lTagIds {
 		tags := make([]Tag, len(tIds))
 		for i, tId := range tIds {

--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -548,11 +548,16 @@ func fillLivestreamResponses(ctx context.Context, tx *sqlx.Tx, models []*Livestr
 
 	livestreams := make([]Livestream, len(models))
 	for i, m := range models {
+		tags, found := lTags[m.ID]
+		if !found {
+			tags = []Tag{}
+		}
+
 		livestreams[i] = Livestream{
 			ID:           m.ID,
 			Owner:        owners[m.UserID],
 			Title:        m.Title,
-			Tags:         lTags[m.ID],
+			Tags:         tags,
 			Description:  m.Description,
 			PlaylistUrl:  m.PlaylistUrl,
 			ThumbnailUrl: m.ThumbnailUrl,

--- a/webapp/go/livestream_handler.go
+++ b/webapp/go/livestream_handler.go
@@ -206,7 +206,7 @@ func searchLivestreamsHandler(c echo.Context) error {
 		}
 
 		// livestreamの取得
-		query, params, err = sqlx.In("SELECT * FROM livestreams WHERE id IN (?)", keyTaggedLivestreamIDs)
+		query, params, err = sqlx.In("SELECT * FROM livestreams WHERE id IN (?) ORDER BY id DESC", keyTaggedLivestreamIDs)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to construct IN query: "+err.Error())
 		}


### PR DESCRIPTION
refs #16

>   417  163.116   0.3912   0.0715   0.031   0.391   0.483   0.505   0.549   0.568    414    0    3    0    25996941          0      62342      63962  GET /api/livestream/search?limit=<num> HTTP/1.1

の中にあるN+1の軽減